### PR TITLE
PERP-4136 | Update osmosis version to 27.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM osmolabs/osmosis:25.0.0-alpine
+FROM osmolabs/osmosis:27.0-alpine
 
 RUN apk add dasel
 


### PR DESCRIPTION
https://hub.docker.com/layers/osmolabs/osmosis/27.0-alpine/images/sha256-3ba87b5c8475bfff1738ccb745fe5d46566185a9bf224be59e115e4c09a9f7ae?context=explore

This is the latest version of osmosis image available in the docker hub.